### PR TITLE
Feature/issue 95 security

### DIFF
--- a/examples/tf-s3-consumer/pom.xml
+++ b/examples/tf-s3-consumer/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <properties>
-    <tf-maven-version>0.6</tf-maven-version>
+    <tf-maven-version>0.7-SNAPSHOT</tf-maven-version>
   </properties>
   <artifactId>tf-s3-consumer</artifactId>
   <groupId>com.deliveredtechnologies.example.maven.tf</groupId>

--- a/examples/tf-s3/pom.xml
+++ b/examples/tf-s3/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <properties>
-    <tf-maven-version>0.6</tf-maven-version>
+    <tf-maven-version>0.7-SNAPSHOT</tf-maven-version>
   </properties>
   <artifactId>tf-s3</artifactId>
   <groupId>com.deliveredtechnologies.example.maven.tf</groupId>

--- a/tf-build-tools/pom.xml
+++ b/tf-build-tools/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.deliveredtechnologies</groupId>
   <artifactId>tf-build-tools</artifactId>
   <packaging>pom</packaging>
-  <version>0.6</version>
+  <version>0.7-SNAPSHOT</version>
   <description>Terraform Build Tools: The parent POM project for Java and Terraform Tools</description>
   <modules>
     <module>tf-cmd-api</module>

--- a/tf-build-tools/tf-cmd-api/pom.xml
+++ b/tf-build-tools/tf-cmd-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>tf-build-tools</artifactId>
     <groupId>com.deliveredtechnologies</groupId>
-    <version>0.6</version>
+    <version>0.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tf-cmd-api</artifactId>

--- a/tf-build-tools/tf-maven-plugin/pom.xml
+++ b/tf-build-tools/tf-maven-plugin/pom.xml
@@ -109,6 +109,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.19</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-dependency-plugin</artifactId>
       <version>3.1.1</version>

--- a/tf-build-tools/tf-maven-plugin/pom.xml
+++ b/tf-build-tools/tf-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.deliveredtechnologies</groupId>
     <artifactId>tf-build-tools</artifactId>
-    <version>0.6</version>
+    <version>0.7-SNAPSHOT</version>
   </parent>
   <artifactId>tf-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/tf-build-tools/tf-s3-archetype/pom.xml
+++ b/tf-build-tools/tf-s3-archetype/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.deliveredtechnologies</groupId>
-    <version>0.6</version>
+    <version>0.7-SNAPSHOT</version>
     <artifactId>tf-build-tools</artifactId>
   </parent>
   <artifactId>tf-s3-archetype</artifactId>

--- a/tf-build-tools/tf-s3-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/tf-build-tools/tf-s3-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <properties>
-    <tf-maven-version>0.6</tf-maven-version>
+    <tf-maven-version>0.7-SNAPSHOT</tf-maven-version>
   </properties>
   <artifactId>${artifactId}</artifactId>
   <groupId>${groupId}</groupId>


### PR DESCRIPTION
* updated commons-compress to remove all but one vulnerability
* jdom is the only vulnerability left; it is needed for reading the Maven XML; there are no known remedies