### PR TITLE
execute a plan against the terraform destroy & apply command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 .gpg
 .flattened-pom.xml
 .DS_Store
+*.json

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Optional Parameters:
 | noColor     | Any    | If this property exists, the -no-color flag is set                                                                 |
 | plan        | String | A terraform plan to apply; if both plan and tfRootDir are specified, only plan is used                             |
 | tfRootDir   | String | A terraform config directory to apply; defaults to `src/main/tf/{first dir found}`, then current directory         |
-| refreshState | Boolean | If set to "true" then Terraform will refresh the state before apply                                               |
+| refreshState | Boolean | If set to "true" then Terraform will refresh the state before apply                                              |
 | timeout     | Number | The maximum time in milliseconds that the terraform apply command can run; defaults to 10min                       |
 | artifact    | String  | Supplied in form {groupId}:{artifactId}:{versionId}; if present, the maven artifact is treated like a root module |
 
@@ -204,10 +204,8 @@ Optional Parameters:
 | tfVars      | String | A comma delimited string of tfvars (e.g. -var 'name=value')                                                        |
 | target      | Number | A resource address to target                                                                                       |
 | noColor     | Any    | If this property exists, the -no-color flag is set                                                                 |
-| tfRootDir   | String | A terraform config directory to destroy; defaults to current directory                                             |
-| plan        | String | A terraform plan to destroy; if both plan and tfRootDir are specified, only plan is used                           |
+| tfRootDir   | String | A terraform config directory to destroy; defaults to current directory                         |
 | timeout     | Number | The maximum time in milliseconds that the terraform destroy command can run; defaults to 10min                     |
-| refreshState | Boolean | If set to "true" then Terraform will refresh the state before destroy                                             |
 | artifact    | String  | Supplied in form {groupId}:{artifactId}:{versionId}; if present, the maven artifact is treated like a root module |
 
 ---

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Optional Parameters:
 | noColor     | Any    | If this property exists, the -no-color flag is set                                                                 |
 | plan        | String | A terraform plan to apply; if both plan and tfRootDir are specified, only plan is used                             |
 | tfRootDir   | String | A terraform config directory to apply; defaults to `src/main/tf/{first dir found}`, then current directory         |
+| refreshState | Boolean | If set to "true" then Terraform will refresh the state before apply                                               |
 | timeout     | Number | The maximum time in milliseconds that the terraform apply command can run; defaults to 10min                       |
 | artifact    | String  | Supplied in form {groupId}:{artifactId}:{versionId}; if present, the maven artifact is treated like a root module |
 
@@ -204,7 +205,9 @@ Optional Parameters:
 | target      | Number | A resource address to target                                                                                       |
 | noColor     | Any    | If this property exists, the -no-color flag is set                                                                 |
 | tfRootDir   | String | A terraform config directory to destroy; defaults to current directory                                             |
+| plan        | String | A terraform plan to destroy; if both plan and tfRootDir are specified, only plan is used                           |
 | timeout     | Number | The maximum time in milliseconds that the terraform destroy command can run; defaults to 10min                     |
+| refreshState | Boolean | If set to "true" then Terraform will refresh the state before destroy                                             |
 | artifact    | String  | Supplied in form {groupId}:{artifactId}:{versionId}; if present, the maven artifact is treated like a root module |
 
 ---

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Optional Parameters:
 | target      | Number | A resource address to target                                                                                       |
 | noColor     | Any    | If this property exists, the -no-color flag is set                                                                 |
 | tfRootDir   | String | A terraform config directory to destroy; defaults to current directory                         |
+| refreshState | Boolean | If set to "true" then Terraform will refresh the state before apply                                              |
 | timeout     | Number | The maximum time in milliseconds that the terraform destroy command can run; defaults to 10min                     |
 | artifact    | String  | Supplied in form {groupId}:{artifactId}:{versionId}; if present, the maven artifact is treated like a root module |
 

--- a/examples/tf-s3-consumer/pom.xml
+++ b/examples/tf-s3-consumer/pom.xml
@@ -9,23 +9,6 @@
   <artifactId>tf-s3-consumer</artifactId>
   <groupId>com.deliveredtechnologies.example.maven.tf</groupId>
   <version>1.0</version>
-  <profiles>
-    <profile>
-      <id>dev</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <tfVarFiles>tfvars/dev.tfvars</tfVarFiles>
-      </properties>
-    </profile>
-    <profile>
-      <id>test</id>
-      <properties>
-        <tfVarFiles>tfvars/test.tfvars</tfVarFiles>
-      </properties>
-    </profile>
-  </profiles>
   <repositories>
     <repository>
       <id>local</id>

--- a/examples/tf-s3/pom.xml
+++ b/examples/tf-s3/pom.xml
@@ -9,23 +9,6 @@
   <artifactId>tf-s3</artifactId>
   <groupId>com.deliveredtechnologies.example.maven.tf</groupId>
   <version>1.0</version>
-  <profiles>
-    <profile>
-      <id>dev</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <tfVarFiles>tfvars/dev.tfvars</tfVarFiles>
-      </properties>
-    </profile>
-    <profile>
-      <id>test</id>
-      <properties>
-        <tfVarFiles>tfvars/test.tfvars</tfVarFiles>
-      </properties>
-  </profile>
-  </profiles>
   <pluginRepositories>
     <pluginRepository>
       <id>sonatype</id>

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformApply.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformApply.java
@@ -121,8 +121,8 @@ public class TerraformApply implements TerraformOperation<String> {
         options.append(properties.getProperty(TerraformApplyParam.plan.property));
       }
 
-      if (properties.containsKey("timeout")) {
-        return terraform.execute(options.toString(), Integer.parseInt(properties.get("timeout").toString()));
+      if (properties.containsKey(TerraformApplyParam.timeout.property)) {
+        return terraform.execute(options.toString(), Integer.parseInt(properties.get(TerraformApplyParam.timeout.property).toString()));
       } else {
         return terraform.execute(options.toString());
       }

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformApply.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformApply.java
@@ -23,6 +23,7 @@ public class TerraformApply implements TerraformOperation<String> {
     target("target"),
     plan("plan"),
     noColor("no-color"),
+    refreshState("refresh"),
     timeout("timeout");
 
     Optional<String> name = Optional.empty();
@@ -75,6 +76,7 @@ public class TerraformApply implements TerraformOperation<String> {
    *   autoApprove - approve without prompt<br>
    *   plan - the plan file to run the apply against<br>
    *   noColor - remove color encoding from output<br>
+   *   refreshState - if true then refresh the state prior to apply<br>
    *   timeout - how long in milliseconds the terraform apply command can run<br>
    * </p>
    * @param properties  parameter options and properties for terraform apply
@@ -87,23 +89,27 @@ public class TerraformApply implements TerraformOperation<String> {
 
     for (TerraformApplyParam param : TerraformApplyParam.values()) {
       if (properties.containsKey(param.property)) {
-        if (param == TerraformApplyParam.tfVarFiles) {
-          for (String file : (properties.getProperty(param.property)).split(",")) {
-            options.append(String.format("-%1$s=%2$s ", param, file.trim()));
+        if (!properties.containsKey(TerraformApplyParam.plan.property)) {
+          if (param == TerraformApplyParam.tfVarFiles) {
+            for (String file : (properties.getProperty(param.property)).split(",")) {
+              options.append(String.format("-%1$s=%2$s ", param, file.trim()));
+            }
+            continue;
           }
-          continue;
-        }
-        if (param == TerraformApplyParam.tfVars) {
-          for (String var : (properties.get(param.property)).toString().split(",")) {
-            options.append(String.format("-%1$s '%2$s' ", param, var.trim()));
+          if (param == TerraformApplyParam.tfVars) {
+            for (String var : (properties.get(param.property)).toString().split(",")) {
+              options.append(String.format("-%1$s '%2$s' ", param, var.trim()));
+            }
+            continue;
           }
-          continue;
         }
         switch (param) {
           case noColor:
             options.append(String.format("-%1$s ", param));
             break;
           case timeout:
+          case tfVarFiles:
+          case tfVars:
           case plan:
             break;
           default:

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformApply.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformApply.java
@@ -89,27 +89,23 @@ public class TerraformApply implements TerraformOperation<String> {
 
     for (TerraformApplyParam param : TerraformApplyParam.values()) {
       if (properties.containsKey(param.property)) {
-        if (!properties.containsKey(TerraformApplyParam.plan.property)) {
-          if (param == TerraformApplyParam.tfVarFiles) {
-            for (String file : (properties.getProperty(param.property)).split(",")) {
-              options.append(String.format("-%1$s=%2$s ", param, file.trim()));
-            }
-            continue;
+        if (param == TerraformApplyParam.tfVarFiles) {
+          for (String file : (properties.getProperty(param.property)).split(",")) {
+            options.append(String.format("-%1$s=%2$s ", param, file.trim()));
           }
-          if (param == TerraformApplyParam.tfVars) {
-            for (String var : (properties.get(param.property)).toString().split(",")) {
-              options.append(String.format("-%1$s '%2$s' ", param, var.trim()));
-            }
-            continue;
+          continue;
+        }
+        if (param == TerraformApplyParam.tfVars) {
+          for (String var : (properties.get(param.property)).toString().split(",")) {
+            options.append(String.format("-%1$s '%2$s' ", param, var.trim()));
           }
+          continue;
         }
         switch (param) {
           case noColor:
             options.append(String.format("-%1$s ", param));
             break;
           case timeout:
-          case tfVarFiles:
-          case tfVars:
           case plan:
             break;
           default:

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
@@ -23,7 +23,6 @@ public class TerraformDestroy implements TerraformOperation<String> {
     tfVars("var"),
     tfVarFiles("var-file"),
     noColor("no-color"),
-    refreshState("refresh"),
     timeout("timeout");
 
     Optional<String> name = Optional.empty();

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
@@ -23,6 +23,7 @@ public class TerraformDestroy implements TerraformOperation<String> {
     tfVars("var"),
     tfVarFiles("var-file"),
     noColor("no-color"),
+    refreshState("refresh"),
     timeout("timeout");
 
     Optional<String> name = Optional.empty();
@@ -68,10 +69,13 @@ public class TerraformDestroy implements TerraformOperation<String> {
    * Executes terraform destroy. <br>
    * <p>
    *   Valid Properties: <br>
+   *   tfVars - a comma delimited list of terraform variables<br>
+   *   varFiles - a comma delimited list of terraform vars files<br>
    *   lockTimeout - state file lock timeout<br>
    *   target - resource target<br>
    *   autoApprove - approve without prompt<br>
    *   noColor - remove color encoding from output<br>
+   *   refreshState - if true then refresh the state prior to apply<br>
    *   timeout - how long in milliseconds the terraform apply command can run<br>
    * </p>
    * @param properties  paramter options and properties for terraform apply
@@ -81,32 +85,34 @@ public class TerraformDestroy implements TerraformOperation<String> {
   @Override
   public String execute(Properties properties) throws TerraformException {
     StringBuilder options = new StringBuilder();
+
     for (TerraformDestroyParam param : TerraformDestroyParam.values()) {
-      if (!properties.containsKey(param.property)) continue;
-
-      if (param == TerraformDestroy.TerraformDestroyParam.tfVarFiles) {
-        for (String file : (properties.getProperty(param.property)).split(",")) {
-          options.append(String.format("-%1$s=%2$s ", param, file.trim()));
+      if (properties.containsKey(param.property)) {
+        if (param == TerraformDestroyParam.tfVarFiles) {
+          for (String file : (properties.getProperty(param.property)).split(",")) {
+            options.append(String.format("-%1$s=%2$s ", param, file.trim()));
+          }
+          continue;
         }
-        continue;
-      }
-      if (param == TerraformDestroyParam.tfVars) {
-        for (String var : (properties.get(param.property)).toString().split(",")) {
-          options.append(String.format("-%1$s '%2$s' ", param, var.trim()));
+        if (param == TerraformDestroyParam.tfVars) {
+          for (String var : (properties.get(param.property)).toString().split(",")) {
+            options.append(String.format("-%1$s '%2$s' ", param, var.trim()));
+          }
+          continue;
         }
-        continue;
-      }
 
-      switch (param) {
-        case lockTimeout:
-        case target:
-          options.append(String.format("-%1$s=%2$s ", param.toString(), properties.getProperty(param.property)));
-          break;
-        case noColor:
-          options.append(String.format("-%1$s ", param));
-          break;
-        default:
-          break;
+        switch (param) {
+          case noColor:
+            options.append(String.format("-%1$s ", param));
+            break;
+          case lockTimeout:
+          case target:
+          case refreshState:
+            options.append(String.format("-%1$s=%2$s ", param, properties.get(param.property)));
+            break;
+          default:
+            break;
+        }
       }
     }
     options.append("-auto-approve ");

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
@@ -23,6 +23,7 @@ public class TerraformDestroy implements TerraformOperation<String> {
     tfVars("var"),
     tfVarFiles("var-file"),
     noColor("no-color"),
+    refreshState("refresh"),
     timeout("timeout");
 
     Optional<String> name = Optional.empty();
@@ -72,6 +73,7 @@ public class TerraformDestroy implements TerraformOperation<String> {
    *   target - resource target<br>
    *   autoApprove - approve without prompt<br>
    *   noColor - remove color encoding from output<br>
+   *   refreshState - if true then refresh the state prior to destroy<br>
    *   timeout - how long in milliseconds the terraform apply command can run<br>
    * </p>
    * @param properties  paramter options and properties for terraform apply

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
@@ -105,13 +105,13 @@ public class TerraformDestroy implements TerraformOperation<String> {
           case noColor:
             options.append(String.format("-%1$s ", param));
             break;
+          case timeout:
+            break;
           case lockTimeout:
           case target:
           case refreshState:
-            options.append(String.format("-%1$s=%2$s ", param, properties.get(param.property)));
-            break;
           default:
-            break;
+            options.append(String.format("-%1$s=%2$s ", param, properties.get(param.property)));
         }
       }
     }

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformDestroy.java
@@ -72,7 +72,6 @@ public class TerraformDestroy implements TerraformOperation<String> {
    *   target - resource target<br>
    *   autoApprove - approve without prompt<br>
    *   noColor - remove color encoding from output<br>
-   *   refreshState - if true then refresh the state prior to destroy<br>
    *   timeout - how long in milliseconds the terraform apply command can run<br>
    * </p>
    * @param properties  paramter options and properties for terraform apply

--- a/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformPlan.java
+++ b/tf-build-tools/tf-cmd-api/src/main/java/com/deliveredtechnologies/terraform/api/TerraformPlan.java
@@ -113,6 +113,7 @@ public class TerraformPlan implements TerraformOperation<String> {
             break;
           case timeout:
             break;
+          case lockTimeout:
           default:
             options.append(String.format("-%1$s=%2$s ", param, properties.get(param.property)));
         }
@@ -124,8 +125,8 @@ public class TerraformPlan implements TerraformOperation<String> {
     }
 
     try {
-      if (properties.containsKey("timeout")) {
-        return terraform.execute(options.toString(), Integer.parseInt(properties.get("timeout").toString()));
+      if (properties.containsKey(TerraformPlanParam.timeout.property)) {
+        return terraform.execute(options.toString(), Integer.parseInt(properties.get(TerraformPlanParam.timeout.property).toString()));
       } else {
         return terraform.execute(options.toString());
       }

--- a/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformApplyTest.java
+++ b/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformApplyTest.java
@@ -39,10 +39,10 @@ public class TerraformApplyTest {
   }
 
   @Test
-  public void terraformApplyExecutesWhenAllPossiblePropertiesArePassedWithoutPlanfile() throws IOException, InterruptedException, TerraformException {
+  public void terraformApplyExecutesWhenAllPossiblePropertiesArePassed() throws IOException, InterruptedException, TerraformException {
     TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.APPLY, this.executable);
     Mockito.when(this.executable.execute(
-      "terraform apply -var 'key1=value1' -var 'key2=value2' -var-file=test1.txt -var-file=test2.txt -lock-timeout=1000 -target=module1.module2 -no-color -auto-approve ",
+      "terraform apply -var 'key1=value1' -var 'key2=value2' -var-file=test1.txt -var-file=test2.txt -lock-timeout=1000 -target=module1.module2 -no-color -auto-approve someplan.tfplan",
       1111))
       .thenReturn("Success!");
     TerraformApply terraformApply = new TerraformApply(terraformDecorator);
@@ -53,26 +53,20 @@ public class TerraformApplyTest {
     this.properties.put(TerraformApplyParam.target.property, "module1.module2");
     this.properties.put(TerraformApplyParam.noColor.property, "true");
     this.properties.put(TerraformApplyParam.timeout.property, "1111");
+    this.properties.put(TerraformApplyParam.plan.property, "someplan.tfplan");
 
     Assert.assertEquals("Success!", terraformApply.execute(properties));
     Mockito.verify(this.executable, Mockito.times(1)).execute(Mockito.anyString(), Mockito.anyInt());
   }
 
   @Test
-  public void terraformApplyExecutesWhenAllPossiblePropertiesArePassedWithPlanfile() throws IOException, InterruptedException, TerraformException {
+  public void terraformApplyExecuteWhenRefreshStatePassedAsFalse() throws IOException, InterruptedException, TerraformException {
     TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.APPLY, this.executable);
-    Mockito.when(this.executable.execute(
-      "terraform apply -lock-timeout=1000 -target=module1.module2 -no-color -auto-approve someplan.tfplan",
-      1111)).thenReturn("Success!");
+    Mockito.when(this.executable.execute("terraform apply -refresh=false -auto-approve ",1111)).thenReturn("Success!");
     TerraformApply terraformApply = new TerraformApply(terraformDecorator);
 
-    this.properties.put(TerraformApplyParam.tfVarFiles.property, "test1.txt, test2.txt");
-    this.properties.put(TerraformApplyParam.tfVars.property, "key1=value1, key2=value2");
-    this.properties.put(TerraformApplyParam.lockTimeout.property, "1000");
-    this.properties.put(TerraformApplyParam.target.property, "module1.module2");
-    this.properties.put(TerraformApplyParam.noColor.property, "true");
-    this.properties.put(TerraformApplyParam.timeout.property, "1111");
-    this.properties.put(TerraformApplyParam.plan.property, "someplan.tfplan");
+    this.properties.put(TerraformApply.TerraformApplyParam.refreshState.property, "false");
+    this.properties.put(TerraformApply.TerraformApplyParam.timeout.property, "1111");
 
     Assert.assertEquals("Success!", terraformApply.execute(properties));
     Mockito.verify(this.executable, Mockito.times(1)).execute(Mockito.anyString(), Mockito.anyInt());

--- a/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformApplyTest.java
+++ b/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformApplyTest.java
@@ -39,12 +39,31 @@ public class TerraformApplyTest {
   }
 
   @Test
-  public void terraformApplyExecutesWhenAllPossiblePropertiesArePassed() throws IOException, InterruptedException, TerraformException {
+  public void terraformApplyExecutesWhenAllPossiblePropertiesArePassedWithoutPlanfile() throws IOException, InterruptedException, TerraformException {
     TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.APPLY, this.executable);
     Mockito.when(this.executable.execute(
-      "terraform apply -var 'key1=value1' -var 'key2=value2' -var-file=test1.txt -var-file=test2.txt -lock-timeout=1000 -target=module1.module2 -no-color -auto-approve someplan.tfplan",
+      "terraform apply -var 'key1=value1' -var 'key2=value2' -var-file=test1.txt -var-file=test2.txt -lock-timeout=1000 -target=module1.module2 -no-color -auto-approve ",
       1111))
       .thenReturn("Success!");
+    TerraformApply terraformApply = new TerraformApply(terraformDecorator);
+
+    this.properties.put(TerraformApplyParam.tfVarFiles.property, "test1.txt, test2.txt");
+    this.properties.put(TerraformApplyParam.tfVars.property, "key1=value1, key2=value2");
+    this.properties.put(TerraformApplyParam.lockTimeout.property, "1000");
+    this.properties.put(TerraformApplyParam.target.property, "module1.module2");
+    this.properties.put(TerraformApplyParam.noColor.property, "true");
+    this.properties.put(TerraformApplyParam.timeout.property, "1111");
+
+    Assert.assertEquals("Success!", terraformApply.execute(properties));
+    Mockito.verify(this.executable, Mockito.times(1)).execute(Mockito.anyString(), Mockito.anyInt());
+  }
+
+  @Test
+  public void terraformApplyExecutesWhenAllPossiblePropertiesArePassedWithPlanfile() throws IOException, InterruptedException, TerraformException {
+    TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.APPLY, this.executable);
+    Mockito.when(this.executable.execute(
+      "terraform apply -lock-timeout=1000 -target=module1.module2 -no-color -auto-approve someplan.tfplan",
+      1111)).thenReturn("Success!");
     TerraformApply terraformApply = new TerraformApply(terraformDecorator);
 
     this.properties.put(TerraformApplyParam.tfVarFiles.property, "test1.txt, test2.txt");

--- a/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformDestroyTest.java
+++ b/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformDestroyTest.java
@@ -42,7 +42,7 @@ public class TerraformDestroyTest {
   public void terraformDestroyExecutesWhenAllPossiblePropertiesArePassed() throws IOException, InterruptedException, TerraformException {
     TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.DESTROY, this.executable);
     Mockito.when(this.executable.execute(
-      "terraform destroy -lock-timeout=1000 -target=module1.module2 -var 'var1=one' -var 'var2=two' -var-file=test1.txt -var-file=test2.txt -no-color -auto-approve ",
+      "terraform destroy -lock-timeout=1000 -target=module1.module2 -var 'var1=one' -var 'var2=two' -var-file=test1.txt -var-file=test2.txt -no-color -refresh=true -auto-approve ",
       1111))
       .thenReturn("Success!");
     TerraformDestroy terraformDestroy = new TerraformDestroy(terraformDecorator);
@@ -53,6 +53,20 @@ public class TerraformDestroyTest {
     this.properties.put(TerraformDestroy.TerraformDestroyParam.timeout.property, "1111");
     this.properties.put(TerraformPlan.TerraformPlanParam.tfVarFiles.property, "test1.txt, test2.txt");
     this.properties.put(TerraformDestroy.TerraformDestroyParam.tfVars.property, "var1=one,var2=two");
+    this.properties.put(TerraformDestroy.TerraformDestroyParam.refreshState.property, "true");
+
+    Assert.assertEquals("Success!", terraformDestroy.execute(properties));
+    Mockito.verify(this.executable, Mockito.times(1)).execute(Mockito.anyString(), Mockito.anyInt());
+  }
+
+  @Test
+  public void terraformDestroyExecuteWhenRefreshStatePassedAsFalse() throws IOException, InterruptedException, TerraformException {
+    TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.DESTROY, this.executable);
+    Mockito.when(this.executable.execute("terraform destroy -refresh=false -auto-approve ",1111)).thenReturn("Success!");
+    TerraformDestroy terraformDestroy = new TerraformDestroy(terraformDecorator);
+
+    this.properties.put(TerraformDestroy.TerraformDestroyParam.refreshState.property, "false");
+    this.properties.put(TerraformDestroy.TerraformDestroyParam.timeout.property, "1111");
 
     Assert.assertEquals("Success!", terraformDestroy.execute(properties));
     Mockito.verify(this.executable, Mockito.times(1)).execute(Mockito.anyString(), Mockito.anyInt());

--- a/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformDestroyTest.java
+++ b/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformDestroyTest.java
@@ -62,7 +62,7 @@ public class TerraformDestroyTest {
   @Test
   public void terraformDestroyExecuteWhenRefreshStatePassedAsFalse() throws IOException, InterruptedException, TerraformException {
     TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.DESTROY, this.executable);
-    Mockito.when(this.executable.execute("terraform destroy -refresh=false -auto-approve ",1111)).thenReturn("Success!");
+    Mockito.when(this.executable.execute("terraform destroy -refresh=false -auto-approve ", 1111)).thenReturn("Success!");
     TerraformDestroy terraformDestroy = new TerraformDestroy(terraformDecorator);
 
     this.properties.put(TerraformDestroy.TerraformDestroyParam.refreshState.property, "false");

--- a/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformPlanTest.java
+++ b/tf-build-tools/tf-cmd-api/src/test/java/com/deliveredtechnologies/terraform/api/TerraformPlanTest.java
@@ -66,6 +66,20 @@ public class TerraformPlanTest {
   }
 
   @Test
+  public void terraformPlanExecuteWhenRefreshStatePassedAsFalse() throws IOException, InterruptedException, TerraformException {
+    TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.PLAN, this.executable);
+    Mockito.when(this.executable.execute("terraform plan -input=true -refresh=false ",1111)).thenReturn("Success!");
+    TerraformPlan terraformPlan = new TerraformPlan(terraformDecorator);
+
+    this.properties.put(TerraformPlan.TerraformPlanParam.planInput.property, "true");
+    this.properties.put(TerraformPlan.TerraformPlanParam.refreshState.property, "false");
+    this.properties.put(TerraformPlan.TerraformPlanParam.timeout.property, "1111");
+
+    Assert.assertEquals("Success!", terraformPlan.execute(properties));
+    Mockito.verify(this.executable, Mockito.times(1)).execute(Mockito.anyString(), Mockito.anyInt());
+  }
+
+  @Test
   public void terraformPlanExecutesWhenNoPropertiesArePassed() throws IOException, InterruptedException, TerraformException {
     TerraformCommandLineDecorator terraformDecorator = new TerraformCommandLineDecorator(TerraformCommand.PLAN, this.executable);
     Mockito.when(this.executable.execute("terraform plan -input=false ")).thenReturn("Success!");

--- a/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Apply.java
+++ b/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Apply.java
@@ -19,6 +19,7 @@ import java.io.IOException;
  */
 @Mojo(name = "apply", requiresProject = false)
 public class Apply extends TerraformMojo<String> {
+
   @Parameter(property = "tfRootDir")
   String tfRootDir;
 
@@ -37,11 +38,17 @@ public class Apply extends TerraformMojo<String> {
   @Parameter(property = "target")
   String target;
 
+  @Parameter(property = "plan")
+  String plan;
+
   @Parameter(property = "noColor")
   boolean noColor = true;
 
   @Parameter(property = "timeout")
   long timeout;
+
+  @Parameter(property = "refreshState")
+  boolean refreshState = true;
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {

--- a/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Destroy.java
+++ b/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Destroy.java
@@ -3,6 +3,7 @@ package com.deliveredtechnologies.maven.terraform.mojo;
 import com.deliveredtechnologies.maven.logs.MavenSlf4jAdapter;
 import com.deliveredtechnologies.maven.terraform.TerraformGetMavenRootArtifact;
 import com.deliveredtechnologies.terraform.TerraformException;
+import com.deliveredtechnologies.terraform.api.TerraformApply;
 import com.deliveredtechnologies.terraform.api.TerraformDestroy;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -19,6 +20,7 @@ import java.io.IOException;
  */
 @Mojo(name = "destroy", requiresProject = false)
 public class Destroy extends TerraformMojo<String> {
+
   @Parameter(property = "tfRootDir")
   String tfRootDir;
 
@@ -37,8 +39,14 @@ public class Destroy extends TerraformMojo<String> {
   @Parameter(property = "target")
   String target;
 
+  @Parameter(property = "plan")
+  String plan;
+
   @Parameter(property = "noColor")
   boolean noColor = true;
+
+  @Parameter(property = "refreshState")
+  boolean refreshState = true;
 
   @Parameter(property = "timeout")
   long timeout;
@@ -50,7 +58,11 @@ public class Destroy extends TerraformMojo<String> {
         TerraformGetMavenRootArtifact mavenRepoExecutableOp = new TerraformGetMavenRootArtifact(artifact, tfRootDir, getLog());
         tfRootDir = mavenRepoExecutableOp.execute(getFieldsAsProperties());
       }
-      execute(new TerraformDestroy(tfRootDir, new MavenSlf4jAdapter(getLog())), getFieldsAsProperties());
+      if (getFieldsAsProperties().containsKey("plan")) {
+        execute(new TerraformApply(tfRootDir, new MavenSlf4jAdapter(getLog())), getFieldsAsProperties());
+      } else {
+        execute(new TerraformDestroy(tfRootDir, new MavenSlf4jAdapter(getLog())), getFieldsAsProperties());
+      }
     } catch (IOException | TerraformException e) {
       throw new MojoExecutionException(e.getMessage(), e);
     }

--- a/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Destroy.java
+++ b/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Destroy.java
@@ -3,7 +3,6 @@ package com.deliveredtechnologies.maven.terraform.mojo;
 import com.deliveredtechnologies.maven.logs.MavenSlf4jAdapter;
 import com.deliveredtechnologies.maven.terraform.TerraformGetMavenRootArtifact;
 import com.deliveredtechnologies.terraform.TerraformException;
-import com.deliveredtechnologies.terraform.api.TerraformApply;
 import com.deliveredtechnologies.terraform.api.TerraformDestroy;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -39,14 +38,8 @@ public class Destroy extends TerraformMojo<String> {
   @Parameter(property = "target")
   String target;
 
-  @Parameter(property = "plan")
-  String plan;
-
   @Parameter(property = "noColor")
   boolean noColor = true;
-
-  @Parameter(property = "refreshState")
-  boolean refreshState = true;
 
   @Parameter(property = "timeout")
   long timeout;
@@ -58,11 +51,7 @@ public class Destroy extends TerraformMojo<String> {
         TerraformGetMavenRootArtifact mavenRepoExecutableOp = new TerraformGetMavenRootArtifact(artifact, tfRootDir, getLog());
         tfRootDir = mavenRepoExecutableOp.execute(getFieldsAsProperties());
       }
-      if (getFieldsAsProperties().containsKey("plan")) {
-        execute(new TerraformApply(tfRootDir, new MavenSlf4jAdapter(getLog())), getFieldsAsProperties());
-      } else {
-        execute(new TerraformDestroy(tfRootDir, new MavenSlf4jAdapter(getLog())), getFieldsAsProperties());
-      }
+      execute(new TerraformDestroy(tfRootDir, new MavenSlf4jAdapter(getLog())), getFieldsAsProperties());
     } catch (IOException | TerraformException e) {
       throw new MojoExecutionException(e.getMessage(), e);
     }

--- a/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Destroy.java
+++ b/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Destroy.java
@@ -38,6 +38,9 @@ public class Destroy extends TerraformMojo<String> {
   @Parameter(property = "target")
   String target;
 
+  @Parameter(property = "refreshState")
+  boolean refreshState = true;
+
   @Parameter(property = "noColor")
   boolean noColor = true;
 

--- a/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Plan.java
+++ b/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/Plan.java
@@ -37,6 +37,9 @@ public class Plan extends TerraformMojo<String> {
   @Parameter(property = "target")
   String target;
 
+  @Parameter(property = "planOutputFile")
+  String planOutputFile;
+
   @Parameter(property = "planInput")
   boolean planInput = false;
 

--- a/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/TerraformMojo.java
+++ b/tf-build-tools/tf-maven-plugin/src/main/java/com/deliveredtechnologies/maven/terraform/mojo/TerraformMojo.java
@@ -66,7 +66,7 @@ public abstract class TerraformMojo<T> extends AbstractMojo {
         field.setAccessible(true);
         Object fieldVal = field.get(this);
         if (fieldVal == null
-            || fieldVal.equals(false)
+            || (fieldVal.equals(false) && !field.getName().startsWith("refresh"))
             || (Number.class.isAssignableFrom(fieldVal.getClass()) && ((Number)fieldVal).longValue() <= 0)) {
           continue;
         }

--- a/tf-build-tools/tf-maven-plugin/src/test/java/com/deliveredtechnologies/maven/terraform/mojo/TerraformMojoStub.java
+++ b/tf-build-tools/tf-maven-plugin/src/test/java/com/deliveredtechnologies/maven/terraform/mojo/TerraformMojoStub.java
@@ -23,6 +23,8 @@ public class TerraformMojoStub extends TerraformMojo<String> {
 
   protected String stringProp;
 
+  protected boolean refreshState;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     // do nothing

--- a/tf-build-tools/tf-maven-plugin/src/test/java/com/deliveredtechnologies/maven/terraform/mojo/TerraformMojoTest.java
+++ b/tf-build-tools/tf-maven-plugin/src/test/java/com/deliveredtechnologies/maven/terraform/mojo/TerraformMojoTest.java
@@ -98,7 +98,7 @@ public class TerraformMojoTest {
 
     properties = terraformMojoStub.getFieldsAsProperties();
 
-    Assert.assertEquals(properties.size(), 4);
+    Assert.assertEquals(properties.size(), 5);
     Assert.assertEquals(properties.get("boolProp"), true);
     Assert.assertEquals(properties.get("intProp"), 22);
     Assert.assertEquals(properties.get("longProp"), 1000L);
@@ -110,7 +110,18 @@ public class TerraformMojoTest {
 
     properties = terraformMojoStub.getFieldsAsProperties();
 
-    Assert.assertEquals(properties.size(), 1);
+    Assert.assertEquals(properties.size(), 2);
     Assert.assertEquals(properties.get("stringProp"), "Hello");
+  }
+
+  @Test
+  public void getFieldAsPropertiesToDisplayRefreshStateFalseParameter() throws MojoExecutionException {
+    TerraformMojoStub terraformMojoStub = new TerraformMojoStub();
+    terraformMojoStub.refreshState = false;
+
+    properties = terraformMojoStub.getFieldsAsProperties();
+
+    Assert.assertEquals(properties.get("refreshState"), false);
+
   }
 }


### PR DESCRIPTION
tf:plan 
1.-DplanOutputFile=create.json should create a plan file.
 2. Added planOutputFile parameter in maven-plugin
tf:apply
 1. Added plan action support
 2. If both plan and var files specified, only plan will be used
tf:destroy
 1. if Plan specifies, apply will be used to destroy using plan files
 2. added plan support and destroys with plan file
updated readme and test cases